### PR TITLE
Persist ColorPuzzleHelp option

### DIFF
--- a/AnodyneArchipelago/Menu/ArchipelagoSettings.cs
+++ b/AnodyneArchipelago/Menu/ArchipelagoSettings.cs
@@ -37,7 +37,7 @@ namespace AnodyneArchipelago.Menu
         public string PlayerSprite = "young_player";
         public MatchDifferentWorldItem MatchDifferentWorldItem = MatchDifferentWorldItem.MatchExtra;
         public bool HideTrapItems = true;
-        internal bool ColorPuzzleHelp = true;
+        public bool ColorPuzzleHelp = true;
 
         public static string GetFilePath() => string.Format("{0}Saves/ap_settings.dat", GameConstants.SavePath);
 


### PR DESCRIPTION
The ColorPuzzleHelp option did not save before because the field was marked internal. I've tested with this change and it now remembers that I've turned the option off.